### PR TITLE
Fix wrong type of `port` and `type` in proxy settings

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -12,8 +12,8 @@ const logger = require('./logger');
 // Proxy Setting
 const proxy = {
   ipaddress: process.env.JET_SOCKS_ADDR || '127.0.0.1',
-  port: process.env.JET_SOCKS_PORT || 1080,
-  type: process.env.JET_SOCKS_TYPE || 5,
+  port: +process.env.JET_SOCKS_PORT || 1080,
+  type: +process.env.JET_SOCKS_TYPE || 5,
 };
 
 // Jet Header


### PR DESCRIPTION
The `process.env` object forces all of its properties to be of type string, but options `proxy.type` in npm/socks requires integer.
